### PR TITLE
[IMP] open_academy: Created session and partner models and related them with previously created course model; generated views to manage these relations T#53764

### DIFF
--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -17,9 +17,11 @@
     'data': [
         'security/ir.model.access.csv',
         'views/course.xml',
+        'views/session.xml',
         'data/ir_ui_menu.xml',
     ],
     'demo': [
         'demo/course.xml',
+        'demo/session.xml',
     ],
 }

--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -13,11 +13,13 @@
     'version': '0.1',
     'depends': [
         'base',
+        'contacts',
     ],
     'data': [
         'security/ir.model.access.csv',
         'views/course.xml',
         'views/session.xml',
+        'views/partner.xml',
         'data/ir_ui_menu.xml',
     ],
     'demo': [

--- a/open_academy/data/ir_ui_menu.xml
+++ b/open_academy/data/ir_ui_menu.xml
@@ -2,4 +2,5 @@
     <menuitem id='menu_open_academy_root' name='Open Academy' sequence='1'/>
     <menuitem id='open_academy_course_menu' name='Courses' action='course_action_display_view' parent='open_academy.menu_open_academy_root' sequence='2'/>
     <menuitem id='open_academy_session_menu' name='Sessions' action='session_action_display_view' parent='open_academy.menu_open_academy_root' sequence='3'/>
+    <menuitem id='open_academy_partner_menu' name='Partners' action='contacts.action_contacts' parent='open_academy.menu_open_academy_root' sequence='4'/>
 </odoo>

--- a/open_academy/data/ir_ui_menu.xml
+++ b/open_academy/data/ir_ui_menu.xml
@@ -1,4 +1,5 @@
 <odoo>
     <menuitem id='menu_open_academy_root' name='Open Academy' sequence='1'/>
-    <menuitem id='open_academy_course_menu' name='Courses' action='course_action_display_view' parent='open_academy.menu_open_academy_root' sequence='10'/>
+    <menuitem id='open_academy_course_menu' name='Courses' action='course_action_display_view' parent='open_academy.menu_open_academy_root' sequence='2'/>
+    <menuitem id='open_academy_session_menu' name='Sessions' action='session_action_display_view' parent='open_academy.menu_open_academy_root' sequence='3'/>
 </odoo>

--- a/open_academy/demo/session.xml
+++ b/open_academy/demo/session.xml
@@ -1,0 +1,22 @@
+<odoo>
+    <record id='session_demo1' model='session'>
+        <field name='name'>Session 1</field>
+        <field name='start_date'>2022-01-07</field>
+        <field name='duration'>2.5</field>
+        <field name='number_of_seats'>20</field>
+    </record>
+
+    <record id='session_demo2' model='session'>
+        <field name='name'>Session 2</field>
+        <field name='start_date'>2022-01-10</field>
+        <field name='duration'>3.5</field>
+        <field name='number_of_seats'>22</field>
+    </record>
+
+    <record id='session_demo3' model='session'>
+        <field name='name'>Session 3</field>
+        <field name='start_date'>2022-01-11</field>
+        <field name='duration'>4.5</field>
+        <field name='number_of_seats'>19</field>
+    </record>
+</odoo>

--- a/open_academy/demo/session.xml
+++ b/open_academy/demo/session.xml
@@ -4,6 +4,7 @@
         <field name='start_date'>2022-01-07</field>
         <field name='duration'>2.5</field>
         <field name='number_of_seats'>20</field>
+        <field name='course_id' ref='course_demo1'/>
     </record>
 
     <record id='session_demo2' model='session'>
@@ -11,6 +12,7 @@
         <field name='start_date'>2022-01-10</field>
         <field name='duration'>3.5</field>
         <field name='number_of_seats'>22</field>
+        <field name='course_id' ref='course_demo1'/>
     </record>
 
     <record id='session_demo3' model='session'>
@@ -18,5 +20,6 @@
         <field name='start_date'>2022-01-11</field>
         <field name='duration'>4.5</field>
         <field name='number_of_seats'>19</field>
+        <field name='course_id' ref='course_demo2'/>
     </record>
 </odoo>

--- a/open_academy/models/__init__.py
+++ b/open_academy/models/__init__.py
@@ -1,2 +1,3 @@
 from . import course 
 from . import session
+from . import partner

--- a/open_academy/models/__init__.py
+++ b/open_academy/models/__init__.py
@@ -1,1 +1,2 @@
 from . import course 
+from . import session

--- a/open_academy/models/course.py
+++ b/open_academy/models/course.py
@@ -5,6 +5,6 @@ class Course(models.Model):
     _name = 'course'
     _description = 'Course'
 
-    title = fields.Char(required = True)
+    title = fields.Char(required=True)
     description = fields.Text()
-
+    responsible_user_id = fields.Many2one('res.users')

--- a/open_academy/models/course.py
+++ b/open_academy/models/course.py
@@ -8,3 +8,4 @@ class Course(models.Model):
     title = fields.Char(required=True)
     description = fields.Text()
     responsible_user_id = fields.Many2one('res.users')
+    session_ids = fields.One2many('session', 'course_id')

--- a/open_academy/models/partner.py
+++ b/open_academy/models/partner.py
@@ -1,0 +1,8 @@
+from odoo import models, fields
+
+
+class ResPartner(models.Model):
+	_inherit = 'res.partner'
+
+	is_instructor = fields.Boolean(help='Is this partner a session instructor?')
+	session_ids = fields.Many2many('session')

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -11,3 +11,4 @@ class Session(models.Model):
     number_of_seats = fields.Integer()
     instructor_id = fields.Many2one('res.partner')
     course_id = fields.Many2one('course', required=True)
+    attendee_ids = fields.Many2many('res.partner')

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -1,0 +1,11 @@
+from odoo import models, fields
+
+
+class Session(models.Model):
+    _name = 'session'
+    _description = 'Session'
+
+    name = fields.Char(required=True)
+    start_date = fields.Date()
+    duration = fields.Float()
+    number_of_seats = fields.Integer()

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -9,3 +9,5 @@ class Session(models.Model):
     start_date = fields.Date()
     duration = fields.Float()
     number_of_seats = fields.Integer()
+    instructor_id = fields.Many2one('res.partner')
+    course_id = fields.Many2one('course', required=True)

--- a/open_academy/security/ir.model.access.csv
+++ b/open_academy/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_open_academy_model_course,access_open_academy_model_course,model_course,base.group_user,1,1,1,1
+access_open_academy_model_session,access_open_academy_model_session,model_session,base.group_user,1,1,1,1

--- a/open_academy/views/course.xml
+++ b/open_academy/views/course.xml
@@ -22,6 +22,7 @@
         <field name='arch' type='xml'>
             <tree>
                 <field name='title'/>
+                <field name='responsible_user_id'/>
                 <field name='description'/>
             </tree>
         </field>

--- a/open_academy/views/partner.xml
+++ b/open_academy/views/partner.xml
@@ -1,0 +1,27 @@
+<odoo>
+    <record id='partner_view_tree_inherited' model='ir.ui.view'>
+        <field name='name'>res.partner.view.tree.inherited</field>
+        <field name='model'>res.partner</field>
+        <field name='inherit_id' ref="base.view_partner_tree"/>
+        <field name='arch' type='xml'>
+            <field name='display_name' position='after'>
+                <field name='session_ids'/>
+                <field name='is_instructor'/>
+            </field>
+        </field>
+    </record>
+
+    <record id='partner_view_form_inherited' model='ir.ui.view'>
+        <field name='name'>res.partner.view.form.inherited</field>
+        <field name='model'>res.partner</field>
+        <field name='inherit_id' ref="base.view_partner_form"/>
+        <field name='arch' type='xml'>
+            <page name='internal_notes' position='after'>
+                <page string='Open Academy sessions'>
+                    <field name='session_ids'/>
+                    <field name='is_instructor'/>
+                </page>
+            </page>
+        </field>
+    </record>
+</odoo>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -1,0 +1,20 @@
+<odoo>
+    <record id='session_view_tree' model='ir.ui.view'>
+        <field name='name'>session.view.tree</field>
+        <field name='model'>session</field>
+        <field name='arch' type='xml'>
+            <tree>
+                <field name='name'/>
+                <field name='start_date'/>
+                <field name='duration' widget='float_time'/>
+                <field name='number_of_seats'/>
+            </tree>
+        </field>
+    </record>
+
+    <record id='session_action_display_view' model='ir.actions.act_window'>
+        <field name='name'>Session</field>
+        <field name='res_model'>session</field>
+        <field name='view_mode'>tree,form</field>
+    </record>
+</odoo>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -5,6 +5,8 @@
         <field name='arch' type='xml'>
             <tree>
                 <field name='name'/>
+                <field name='course_id'/>
+                <field name='instructor_id'/>
                 <field name='start_date'/>
                 <field name='duration' widget='float_time'/>
                 <field name='number_of_seats'/>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -10,6 +10,7 @@
                 <field name='start_date'/>
                 <field name='duration' widget='float_time'/>
                 <field name='number_of_seats'/>
+                <field name='attendee_ids'/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
A Session model was defined. Sessions relate to courses by their ids and have durations, instructors, attendees and starting dates.
![image](https://user-images.githubusercontent.com/49595803/149257043-72087da3-cb9b-4749-a229-a81920f1a7f8.png)

A responsible user field was defined for the course model and put in the form view.
![image](https://user-images.githubusercontent.com/49595803/149257177-f50f05cc-6640-40ec-8879-0a7fc54f820b.png)

Partners had their views inherited from the res.partner view using view inheritance. 
![image](https://user-images.githubusercontent.com/49595803/149393079-8010579a-0044-42e1-8ce8-ac27d85db26c.png)

Partners can manage the course sessions they will be attending to by clicking on the Open Academy sessions tab and adding a line from which the following window pops out:
![image](https://user-images.githubusercontent.com/49595803/149393151-f8c6ddc1-79ae-4317-a9c4-c50c63e49f38.png)