### PR TITLE
[IMP] Added domains, computed values and onchange mechanism to Session model; created Teacher categories on partner model

### DIFF
--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -25,5 +25,6 @@
     'demo': [
         'demo/course.xml',
         'demo/session.xml',
+        'demo/category.xml',
     ],
 }

--- a/open_academy/demo/category.xml
+++ b/open_academy/demo/category.xml
@@ -1,0 +1,13 @@
+<odoo>
+    <record id='teacher_level_1' model='res.partner.category'>
+        <field name='name'>Teacher / Level 1</field>
+    </record>
+
+    <record id='teacher_level_2' model='res.partner.category'>
+        <field name='name'>Teacher / Level 2</field>
+    </record>
+
+    <record id='teacher_level_3' model='res.partner.category'>
+        <field name='name'>Teacher / Level 3</field>
+    </record>
+</odoo>

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -20,3 +20,23 @@ class Session(models.Model):
         for record in self:
             taken_seats_percentage = int(100*len(record.attendee_ids)/record.number_of_seats) if record.number_of_seats > 0 else 0
             record.taken_seats_percentage = taken_seats_percentage
+
+    @api.onchange('attendee_ids', 'number_of_seats')
+    def _onchange_seats(self):
+        warning_message = [] 
+
+        if self.number_of_seats < len(self.attendee_ids):
+            if self.number_of_seats < 0:
+                warning_message.append('There cannot be less than 0 seats available.')
+
+            self.number_of_seats = self._origin.number_of_seats
+            self.attendee_ids = self._origin.attendee_ids
+            warning_message.append('Maximum seat capacity exceeded; discarded operation.')
+
+        if warning_message:
+            return {
+                'warning': {
+                    'title': 'Error in number of seats or attendees',
+                    'message': ' '.join(warning_message),
+                }
+            }

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class Session(models.Model):
@@ -12,3 +12,10 @@ class Session(models.Model):
     instructor_id = fields.Many2one('res.partner', domain="['|',('is_instructor', '=', True),('category_id.name', 'like', 'Teacher')]")
     course_id = fields.Many2one('course', required=True)
     attendee_ids = fields.Many2many('res.partner')
+    taken_seats_percentage = fields.Char('Taken Seats %', compute='_compute_taken_seats_percentage')
+
+    @api.depends('attendee_ids', 'number_of_seats')
+    def _compute_taken_seats_percentage(self):
+        for record in self:
+            taken_seats_percentage = int(100*len(record.attendee_ids)/record.number_of_seats) if record.number_of_seats > 0 else 0
+            record.taken_seats_percentage = taken_seats_percentage

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -6,7 +6,8 @@ class Session(models.Model):
     _description = 'Session'
 
     name = fields.Char(required=True)
-    start_date = fields.Date()
+    start_date = fields.Date(default=fields.Date.today)
+    active = fields.Boolean(default=True)
     duration = fields.Float()
     number_of_seats = fields.Integer()
     instructor_id = fields.Many2one('res.partner', domain="['|',('is_instructor', '=', True),('category_id.name', 'like', 'Teacher')]")

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -9,6 +9,6 @@ class Session(models.Model):
     start_date = fields.Date()
     duration = fields.Float()
     number_of_seats = fields.Integer()
-    instructor_id = fields.Many2one('res.partner')
+    instructor_id = fields.Many2one('res.partner', domain="[('is_instructor', '=', True)")
     course_id = fields.Many2one('course', required=True)
     attendee_ids = fields.Many2many('res.partner')

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -9,6 +9,6 @@ class Session(models.Model):
     start_date = fields.Date()
     duration = fields.Float()
     number_of_seats = fields.Integer()
-    instructor_id = fields.Many2one('res.partner', domain="[('is_instructor', '=', True)")
+    instructor_id = fields.Many2one('res.partner', domain="['|',('is_instructor', '=', True),('category_id.name', 'like', 'Teacher')]")
     course_id = fields.Many2one('course', required=True)
     attendee_ids = fields.Many2many('res.partner')

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -11,7 +11,29 @@
                 <field name='duration' widget='float_time'/>
                 <field name='number_of_seats'/>
                 <field name='attendee_ids'/>
+                <field name='taken_seats_percentage' widget="progressbar"/>
             </tree>
+        </field>
+    </record>
+
+    <record id='session_view_form' model='ir.ui.view'>
+        <field name='name'>session.view.form</field>
+        <field name='model'>session</field>
+        <field name='arch' type='xml'>
+            <form>
+                <sheet>
+                    <group>
+                        <field name='name'/>
+                        <field name='course_id'/>
+                        <field name='instructor_id'/>
+                        <field name='start_date'/>
+                        <field name='duration' widget='float_time'/>
+                        <field name='number_of_seats'/>
+                        <field name='attendee_ids'/>
+                        <field name='taken_seats_percentage' widget="progressbar"/>
+                    </group>
+                </sheet>
+            </form>
         </field>
     </record>
 

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -4,7 +4,7 @@
         <field name='model'>session</field>
         <field name='arch' type='xml'>
             <tree>
-                <field name='name'/>
+                <field name='active'/>
                 <field name='course_id'/>
                 <field name='instructor_id'/>
                 <field name='start_date'/>
@@ -23,6 +23,7 @@
             <form>
                 <sheet>
                     <group>
+                        <field name='active'/>
                         <field name='name'/>
                         <field name='course_id'/>
                         <field name='instructor_id'/>


### PR DESCRIPTION
Added 'Teacher / Level ' domain and demo data to res.partner.category model, such that instructors without a teacher level or is_instructor=True cannot be added as instructors. 
![image](https://user-images.githubusercontent.com/49595803/149590897-a8cb86f6-a1b1-4fce-88f5-c958fd655175.png)

Added computed values for % of taken seats in Session model and onchange mechanism to prevent invalid values, such as negative number of seats and more attendees than available seats. Displayed the % of taken seats as progress bar, added 'is_active' field to Session and defaulted the start_date field to today.
![image](https://user-images.githubusercontent.com/49595803/149589975-f68e9dd6-9afa-4c71-9f76-8568653e0b0f.png)
