### PR TITLE
[IMP] open_academy: Added Python constraint and multiple views to Session model; added filtering button and SQL constraints to Course model; modified security for both models T#53764

### DIFF
--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -13,6 +13,7 @@
         'contacts',
     ],
     'data': [
+        'security/res_groups.xml',
         'security/ir.model.access.csv',
         'views/course.xml',
         'views/session.xml',
@@ -23,5 +24,6 @@
         'demo/course.xml',
         'demo/session.xml',
         'demo/category.xml',
+        'demo/res_users.xml',
     ],
 }

--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -14,6 +14,7 @@
     ],
     'data': [
         'security/res_groups.xml',
+        'security/ir_rule.xml',
         'security/ir.model.access.csv',
         'views/course.xml',
         'views/session.xml',

--- a/open_academy/demo/course.xml
+++ b/open_academy/demo/course.xml
@@ -1,10 +1,12 @@
 <odoo>
     <record id='course_demo1' model='course'>
         <field name='title'>Python Course</field>
+        <field name='name'>Python Course</field>
     </record>
 
     <record id='course_demo2' model='course'>
         <field name='title'>Odoo Course</field>
+        <field name='name'>Odoo Course</field>
         <field name='description'>This is the course's description.</field>
     </record>
 </odoo>

--- a/open_academy/demo/course.xml
+++ b/open_academy/demo/course.xml
@@ -1,10 +1,10 @@
 <odoo>
     <record id='course_demo1' model='course'>
-        <field name='title'>Curso Python</field>
+        <field name='title'>Python Course</field>
     </record>
 
     <record id='course_demo2' model='course'>
-        <field name='title'>Curso Odoo</field>
-        <field name='description'>Prueba</field>
+        <field name='title'>Odoo Course</field>
+        <field name='description'>This is the course's description.</field>
     </record>
 </odoo>

--- a/open_academy/demo/res_users.xml
+++ b/open_academy/demo/res_users.xml
@@ -1,0 +1,10 @@
+<odoo> 
+    <record id='john_smith' model='res.users' context='{"no_reset_password": True}'>
+        <field name='login'>john_smith</field>
+        <field name='password'>john_smith</field>
+        <field name='name'>John Smith</field>
+        <field name='email'>john@smith.com</field>
+        <field name='active'>True</field>
+        <field name='groups_id' eval='[(6,0,[ref("base.group_user"), ref("open_academy_session_read")])]'/>
+    </record>
+</odoo>

--- a/open_academy/demo/session.xml
+++ b/open_academy/demo/session.xml
@@ -1,24 +1,45 @@
 <odoo>
     <record id='session_demo1' model='session'>
         <field name='name'>Session 1</field>
-        <field name='start_date'>2022-01-07</field>
         <field name='duration'>2.5</field>
+        <field name='start_date'>2022-01-07</field>
+        <field name='stop_date'>2022-01-09</field>
         <field name='number_of_seats'>20</field>
         <field name='course_id' ref='course_demo1'/>
     </record>
 
     <record id='session_demo2' model='session'>
         <field name='name'>Session 2</field>
-        <field name='start_date'>2022-01-10</field>
         <field name='duration'>3.5</field>
+        <field name='start_date'>2022-01-10</field>
+        <field name='stop_date'>2022-01-13</field>
         <field name='number_of_seats'>22</field>
         <field name='course_id' ref='course_demo1'/>
     </record>
 
     <record id='session_demo3' model='session'>
         <field name='name'>Session 3</field>
-        <field name='start_date'>2022-01-11</field>
         <field name='duration'>4.5</field>
+        <field name='start_date'>2022-01-11</field>
+        <field name='stop_date'>2022-01-16</field>
+        <field name='number_of_seats'>19</field>
+        <field name='course_id' ref='course_demo2'/>
+    </record>
+
+    <record id='session_demo4' model='session'>
+        <field name='name'>Session 4</field>
+        <field name='duration'>3.5</field>
+        <field name='start_date'>2022-01-12</field>
+        <field name='stop_date'>2022-01-20</field>
+        <field name='number_of_seats'>19</field>
+        <field name='course_id' ref='course_demo2'/>
+    </record>
+
+    <record id='session_demo5' model='session'>
+        <field name='name'>Session 5</field>
+        <field name='duration'>6.5</field>
+        <field name='start_date'>2022-01-13</field>
+        <field name='stop_date'>2022-01-29</field>
         <field name='number_of_seats'>19</field>
         <field name='course_id' ref='course_demo2'/>
     </record>

--- a/open_academy/models/course.py
+++ b/open_academy/models/course.py
@@ -5,7 +5,8 @@ class Course(models.Model):
     _name = 'course'
     _description = 'Course'
 
-    title = fields.Char(required=True)
+    name = fields.Char(required=True)
+    title = fields.Char(required=True, copy=False)
     description = fields.Text()
     responsible_user_id = fields.Many2one('res.users')
     session_ids = fields.One2many('session', 'course_id')
@@ -21,3 +22,11 @@ class Course(models.Model):
             'The course name must be unique!'
         ),
     ]
+
+    def copy(self):
+        new_title = f'copy of [{self.title}]'
+        count = self.search_count([('title', 'like', new_title), ])
+        new_title += f' ({count})' if count > 0 else ''
+        default = {'title': new_title, }
+
+        return super().copy(default=default)

--- a/open_academy/models/course.py
+++ b/open_academy/models/course.py
@@ -9,3 +9,15 @@ class Course(models.Model):
     description = fields.Text()
     responsible_user_id = fields.Many2one('res.users')
     session_ids = fields.One2many('session', 'course_id')
+    _sql_constraints = [
+        (
+            'description',
+            'CHECK(title != description)',
+            'The course title and the course description must be different!'
+        ),
+        (
+            'title',
+            'UNIQUE(title)',
+            'The course name must be unique!'
+        ),
+    ]

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -1,4 +1,5 @@
-from odoo import models, fields, api
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
 
 
 class Session(models.Model):
@@ -44,3 +45,10 @@ class Session(models.Model):
                     'message': ' '.join(warning_message),
                 }
             }
+
+    @api.constrains('attendee_ids', 'instructor_id')
+    def _check_instructor_id_in_attendee_ids(self):
+        for record in self:
+            if record.instructor_id in record.attendee_ids:
+                error_message = _('Instructor cannot be an attendee for their own session!')
+                raise ValidationError(error_message)

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -20,6 +20,7 @@ class Session(models.Model):
     course_id = fields.Many2one('course', required=True)
     attendee_ids = fields.Many2many('res.partner')
     taken_seats_percentage = fields.Char('Taken Seats %', compute='_compute_taken_seats_percentage')
+    attendee_count = fields.Integer(compute='_compute_attendee_count', store=True)
 
     @api.depends('attendee_ids', 'number_of_seats')
     def _compute_taken_seats_percentage(self):
@@ -65,3 +66,8 @@ class Session(models.Model):
             d1 = datetime.strptime(start_date, fmt)
             d2 = datetime.strptime(stop_date, fmt)
             record.lasting_days = (d2 - d1).days
+
+    @api.depends('attendee_ids')
+    def _compute_attendee_count(self):
+        for record in self:
+            record.attendee_count = len(record.attendee_ids)

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -19,8 +19,9 @@ class Session(models.Model):
     )
     course_id = fields.Many2one('course', required=True)
     attendee_ids = fields.Many2many('res.partner')
-    taken_seats_percentage = fields.Char('Taken Seats %', compute='_compute_taken_seats_percentage')
+    taken_seats_percentage = fields.Integer('Taken Seats %', compute='_compute_taken_seats_percentage')
     attendee_count = fields.Integer(compute='_compute_attendee_count', store=True)
+    available_seats = fields.Integer(compute='_compute_available_seats', store=True)
 
     @api.depends('attendee_ids', 'number_of_seats')
     def _compute_taken_seats_percentage(self):
@@ -71,3 +72,8 @@ class Session(models.Model):
     def _compute_attendee_count(self):
         for record in self:
             record.attendee_count = len(record.attendee_ids)
+
+    @api.depends('attendee_ids', 'number_of_seats')
+    def _compute_available_seats(self):
+        for record in self:
+            record.available_seats = record.number_of_seats - len(record.attendee_ids)

--- a/open_academy/models/session.py
+++ b/open_academy/models/session.py
@@ -1,5 +1,6 @@
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
+from datetime import datetime
 
 
 class Session(models.Model):
@@ -8,6 +9,8 @@ class Session(models.Model):
 
     name = fields.Char(required=True)
     start_date = fields.Date(default=fields.Date.today)
+    stop_date = fields.Date()
+    lasting_days = fields.Integer(compute='_compute_lasting_days')
     active = fields.Boolean(default=True)
     duration = fields.Float()
     number_of_seats = fields.Integer()
@@ -52,3 +55,13 @@ class Session(models.Model):
             if record.instructor_id in record.attendee_ids:
                 error_message = _('Instructor cannot be an attendee for their own session!')
                 raise ValidationError(error_message)
+
+    @api.depends('start_date', 'stop_date')
+    def _compute_lasting_days(self):
+        for record in self:
+            fmt = '%Y-%m-%d'
+            start_date = str(record.start_date)
+            stop_date = str(record.stop_date)
+            d1 = datetime.strptime(start_date, fmt)
+            d2 = datetime.strptime(stop_date, fmt)
+            record.lasting_days = (d2 - d1).days

--- a/open_academy/security/ir.model.access.csv
+++ b/open_academy/security/ir.model.access.csv
@@ -1,4 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_open_academy_model_course,access_open_academy_model_course,model_course,base.group_user,1,1,1,1
-access_open_academy_model_session,access_open_academy_model_session,model_session,base.group_user,1,1,1,1
+access_open_academy_model_course,access_open_academy_model_course,model_course,base.group_user,1,0,0,0
+access_open_academy_model_session,access_open_academy_model_session,model_session,base.group_user,1,0,0,0
 read_access_open_academy_model_session,read_access_open_academy_model_session,model_session,open_academy_session_read,1,0,0,0
+access_open_academy_model_course_manager,access_open_academy_model_course_manager,model_course,open_academy_manager,1,1,1,1
+access_open_academy_model_session_manager,access_open_academy_model_session_manager,model_session,open_academy_manager,1,1,1,1

--- a/open_academy/security/ir.model.access.csv
+++ b/open_academy/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_open_academy_model_course,access_open_academy_model_course,model_course,base.group_user,1,1,1,1
 access_open_academy_model_session,access_open_academy_model_session,model_session,base.group_user,1,1,1,1
+read_access_open_academy_model_session,read_access_open_academy_model_session,model_session,open_academy_session_read,1,0,0,0

--- a/open_academy/security/ir_rule.xml
+++ b/open_academy/security/ir_rule.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <record id='responsible_user_write_unlink' model='ir.rule'>
+        <field name='name'>Open Academy: Write or delete own courses</field>
+        <field name='model_id' ref='model_course'/>
+        <field name='groups' eval='[(4, ref("open_academy_manager"))]'/>
+        <field name='perm_read' eval='0'/>
+        <field name='perm_write' eval='1'/>
+        <field name='perm_create' eval='0'/>
+        <field name='perm_unlink' eval='1'/>
+        <field name='domain_force'>
+            ['|', ('responsible_user_id', '=', user.id), ('responsible_user_id', '=', False)]
+        </field>
+    </record>
+</odoo>

--- a/open_academy/security/res_groups.xml
+++ b/open_academy/security/res_groups.xml
@@ -2,4 +2,8 @@
     <record id='open_academy_session_read' model='res.groups'>
         <field name='name'>OpenAcademy / Session Read</field>
     </record>
+    
+    <record id='open_academy_manager' model='res.groups'>
+        <field name='name'>OpenAcademy / Manager</field>
+    </record>
 </odoo>

--- a/open_academy/security/res_groups.xml
+++ b/open_academy/security/res_groups.xml
@@ -1,0 +1,5 @@
+<odoo>
+    <record id='open_academy_session_read' model='res.groups'>
+        <field name='name'>OpenAcademy / Session Read</field>
+    </record>
+</odoo>

--- a/open_academy/views/course.xml
+++ b/open_academy/views/course.xml
@@ -6,6 +6,7 @@
             <form>
                 <sheet>
                     <h1><field name='title'/></h1>
+                    <field name='responsible_user_id' placeholder='Responsible User'/>
                     <notebook>
                         <page string='description'>
                             <field name="description" placeholder="This is the description of the course"/>
@@ -28,13 +29,18 @@
         </field>
     </record>
 
-    <record id='course_view_search' model="ir.ui.view">
-        <field name="name">course.view.search</field>
-        <field name="model">course</field>
-        <field name="arch" type="xml">
+    <record id='course_view_search' model='ir.ui.view'>
+        <field name='name'>course.view.search</field>
+        <field name='model'>course</field>
+        <field name='arch' type='xml'>
             <search>
-                <field name="title"/>
-                <field name="description"/>
+                <field name='title'/>
+                <field name='description'/>
+
+                <filter name='responsible_user_id' domain='[("responsible_user_id","=", uid)]'/>
+                <group string='Group By'>
+                    <filter name='group_by_responsible_user' context='{"group_by": "responsible_user_id"}'/>
+                </group>
             </search>
         </field>
     </record>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -58,9 +58,17 @@
         </field>
     </record>
 
+    <record id='session_view_gantt' model='ir.ui.view'>
+        <field name='name'>session.view.gantt</field>
+        <field name='model'>session</field>
+        <field name='arch' type='xml'>
+            <gantt string="Sessions by Instructor" date_start="start_date" date_stop="stop_date" progress="taken_seats_percentage" default_group_by="instructor_id"/>
+        </field>
+    </record>
+
     <record id='session_action_display_view' model='ir.actions.act_window'>
         <field name='name'>Session</field>
         <field name='res_model'>session</field>
-        <field name='view_mode'>tree,calendar,form</field>
+        <field name='view_mode'>tree,calendar,gantt,form</field>
     </record>
 </odoo>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -40,9 +40,27 @@
         </field>
     </record>
 
+    <record id='session_view_calendar' model='ir.ui.view'>
+        <field name='name'>session.view.calendar</field>
+        <field name='model'>session</field>
+        <field name='arch' type='xml'>
+            <calendar string='name' date_start='start_date' date_stop='stop_date' color='course_id'>
+                <field name='active'/>
+                <field name='name'/>
+                <field name='course_id'/>
+                <field name='instructor_id'/>
+                <field name='start_date'/>
+                <field name='stop_date'/>
+                <field name='duration' widget='float_time'/>
+                <field name='number_of_seats'/>
+                <field name='taken_seats_percentage' widget="progressbar"/>
+            </calendar>
+        </field>
+    </record>
+
     <record id='session_action_display_view' model='ir.actions.act_window'>
         <field name='name'>Session</field>
         <field name='res_model'>session</field>
-        <field name='view_mode'>tree,form</field>
+        <field name='view_mode'>tree,calendar,form</field>
     </record>
 </odoo>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -66,9 +66,20 @@
         </field>
     </record>
 
+    <record id='session_view_graph' model='ir.ui.view'>
+        <field name='name'>session.view.graph</field>
+        <field name='model'>session</field>
+        <field name='arch' type='xml'>
+            <graph string='Attendee count per course'>
+                <field name='course_id'/>
+                <field name='attendee_count' type='measure'/>
+            </graph>
+        </field>
+    </record>
+
     <record id='session_action_display_view' model='ir.actions.act_window'>
         <field name='name'>Session</field>
         <field name='res_model'>session</field>
-        <field name='view_mode'>tree,calendar,gantt,form</field>
+        <field name='view_mode'>tree,calendar,gantt,form,graph</field>
     </record>
 </odoo>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -77,9 +77,66 @@
         </field>
     </record>
 
+    <record id='session_view_kanban' model='ir.ui.view'>
+        <field name='name'>session.view.kanban</field>
+        <field name='model'>session</field>
+        <field name='arch' type='xml'>
+            <kanban default_group_by='course_id'>
+                <field name='active'/>
+                <field name='course_id'/>
+                <field name='instructor_id'/>
+                <field name='start_date'/>
+                <field name='stop_date'/>
+                <field name='duration'/>
+                <field name='number_of_seats'/>
+                <field name='attendee_ids'/>
+                <field name='taken_seats_percentage'/>
+                <field name='available_seats'/>
+
+                <templates>
+                    <t t-name="kanban-box">
+                        <div class="oe_kanban_global_click">
+                            <div class="oe_kanban_details d-flex flex-column">
+                                <strong class="o_kanban_record_title oe_partner_heading"><field name="name"/></strong>
+                                <div class="o_kanban_tags_section oe_kanban_partner_categories"/>
+                                <ul>
+                                    <li t-if='record.instructor_id.raw_value'><span>Instructor: </span><field name="instructor_id"/></li>
+                                    <li>
+                                        <t t-if='record.start_date.raw_value'><span>From </span><field name="start_date"/></t>
+                                        <t t-if='record.stop_date.raw_value'><span>To </span><field name="stop_date"/></t>
+                                    </li>
+                                    <li><span>Duration: <field name="duration" widget='float_time'/></span></li>
+                                    <li><span>Seating capacity: <field name="number_of_seats"/></span></li>
+                                </ul>
+                                <div>
+                                    <strong>Progress</strong><br></br>
+                                    <field name='taken_seats_percentage' widget='progressbar'/>
+                                    <div t-if="record.number_of_seats.raw_value">
+                                        <p class='text-primary' t-if='record.taken_seats_percentage.value&lt;70'>
+                                            <field name='available_seats'/> seats available
+                                        </p>
+                                        <p class='text-warning' t-elif='record.taken_seats_percentage.value&lt;100'>
+                                            Only <field name='available_seats'/> seats available!
+                                        </p>
+                                        <p class='text-danger' t-elif='record.taken_seats_percentage.value==100'>
+                                            Registration closed
+                                        </p>
+                                        <p class='text-secondary' t-else=''>
+                                            Seat availability could not be retrieved
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
     <record id='session_action_display_view' model='ir.actions.act_window'>
         <field name='name'>Session</field>
         <field name='res_model'>session</field>
-        <field name='view_mode'>tree,calendar,gantt,form,graph</field>
+        <field name='view_mode'>tree,calendar,kanban,gantt,form,graph</field>
     </record>
 </odoo>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -3,15 +3,16 @@
         <field name='name'>session.view.tree</field>
         <field name='model'>session</field>
         <field name='arch' type='xml'>
-            <tree>
+            <tree decoration-info='lasting_days&lt;5' decoration-danger='lasting_days&gt;15'>
                 <field name='active'/>
                 <field name='course_id'/>
                 <field name='instructor_id'/>
                 <field name='start_date'/>
+                <field name='lasting_days'/>
                 <field name='duration' widget='float_time'/>
                 <field name='number_of_seats'/>
                 <field name='attendee_ids'/>
-                <field name='taken_seats_percentage' widget="progressbar"/>
+                <field name='taken_seats_percentage' widget='progressbar'/>
             </tree>
         </field>
     </record>
@@ -28,10 +29,11 @@
                         <field name='course_id'/>
                         <field name='instructor_id'/>
                         <field name='start_date'/>
+                        <field name='stop_date'/>
                         <field name='duration' widget='float_time'/>
                         <field name='number_of_seats'/>
                         <field name='attendee_ids'/>
-                        <field name='taken_seats_percentage' widget="progressbar"/>
+                        <field name='taken_seats_percentage' widget='progressbar'/>
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
Python constraint on Session: instructors can no longer be attendees for their own sessions. A validation error is thrown if attempted:
![image](https://user-images.githubusercontent.com/49595803/150040174-1ab05579-c63c-446e-a952-78e9f7594c6b.png)

SQL constraints on Course: the course title must be different from its description, and no two courses can have the same title. The Copy method was overriden to duplicate courses but modifying their names, as shown:
![image](https://user-images.githubusercontent.com/49595803/150040498-317a298f-14a8-4711-ba52-50bcdbbb2a4d.png)

The calendar, gantt chart, graph and kanban views were added to Session:
![image](https://user-images.githubusercontent.com/49595803/150041428-9421721d-bec3-404a-a122-ff8e549afd16.png)

The group 'OpenAcademy / Session Read' was created, and given only read access rights on  the Course model:
![image](https://user-images.githubusercontent.com/49595803/150213974-b754ade6-1d67-424e-b85d-84b29512268d.png)

The user 'John Smith' was created and put in the group 'OpenAcademy / Session Read':
![image](https://user-images.githubusercontent.com/49595803/150214202-c8c0b8d6-3985-4be2-b1c1-d65fc181e15f.png)


Finally, the group 'OpenAcademy / Manager' was created, and made so that only users from that group have complete access rights over Course and Session; also, if a course has a responsible user, only that user will be able to modify it:
![image](https://user-images.githubusercontent.com/49595803/150213706-853c0d85-917e-4b94-bfd2-af3e2eb8cdd4.png)





