### PR TITLE
[IMP] open_academy: Added reports to session model; added a dashboard; added a python script to communicate with the Odoo server  T#53764

### DIFF
--- a/open_academy/__init__.py
+++ b/open_academy/__init__.py
@@ -1,2 +1,3 @@
 from . import wizards
+from . import controllers
 from . import models

--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -20,6 +20,7 @@
         'views/course.xml',
         'views/session.xml',
         'views/partner.xml',
+        'views/report_session.xml',
         'data/ir_ui_menu.xml',
     ],
     'demo': [

--- a/open_academy/__manifest__.py
+++ b/open_academy/__manifest__.py
@@ -11,6 +11,7 @@
     'depends': [
         'base',
         'contacts',
+        'board',
     ],
     'data': [
         'security/res_groups.xml',
@@ -21,6 +22,7 @@
         'views/session.xml',
         'views/partner.xml',
         'views/report_session.xml',
+        'views/dashboard.xml',
         'data/ir_ui_menu.xml',
     ],
     'demo': [

--- a/open_academy/controllers/__init__.py
+++ b/open_academy/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/open_academy/controllers/main.py
+++ b/open_academy/controllers/main.py
@@ -1,0 +1,10 @@
+from odoo import http
+
+
+# This controller is added to bypass the error:
+# "edit_custom() missing 1 required positional argument: 'custom_id'".
+# when changing the layout of a dashboard.
+class DashboardController(http.Controller):
+    @http.route('/web/view/edit_custom', type='json', auth="user")
+    def edit_custom(self, arch):
+        return {'result': True}

--- a/open_academy/data/ir_ui_menu.xml
+++ b/open_academy/data/ir_ui_menu.xml
@@ -1,6 +1,7 @@
 <odoo>
     <menuitem id='menu_open_academy_root' name='Open Academy' sequence='1'/>
-    <menuitem id='open_academy_course_menu' name='Courses' action='course_action_display_view' parent='open_academy.menu_open_academy_root' sequence='2'/>
-    <menuitem id='open_academy_session_menu' name='Sessions' action='session_action_display_view' parent='open_academy.menu_open_academy_root' sequence='3'/>
-    <menuitem id='open_academy_partner_menu' name='Partners' action='contacts.action_contacts' parent='open_academy.menu_open_academy_root' sequence='4'/>
+    <menuitem id='open_academy_dashboard_menu' name='Dashboard' action='dashboard_display_view' parent='open_academy.menu_open_academy_root' sequence='2'/>
+    <menuitem id='open_academy_course_menu' name='Courses' action='course_action_display_view' parent='open_academy.menu_open_academy_root' sequence='3'/>
+    <menuitem id='open_academy_session_menu' name='Sessions' action='session_action_display_view' parent='open_academy.menu_open_academy_root' sequence='4'/>
+    <menuitem id='open_academy_partner_menu' name='Partners' action='contacts.action_contacts' parent='open_academy.menu_open_academy_root' sequence='5'/>
 </odoo>

--- a/open_academy/demo/res_users.xml
+++ b/open_academy/demo/res_users.xml
@@ -7,4 +7,13 @@
         <field name='active'>True</field>
         <field name='groups_id' eval='[(6,0,[ref("base.group_user"), ref("open_academy_session_read")])]'/>
     </record>
+
+    <record id='payen' model='res.users' context='{"no_reset_password": True}'>
+        <field name='login'>payen</field>
+        <field name='password'>payen</field>
+        <field name='name'>payen</field>
+        <field name='email'>payen@payen.payen</field>
+        <field name='active'>True</field>
+        <field name='groups_id' eval='[(6,0,[ref("base.group_user"), ref("open_academy_manager")])]'/>
+    </record>
 </odoo>

--- a/open_academy/views/dashboard.xml
+++ b/open_academy/views/dashboard.xml
@@ -1,0 +1,42 @@
+<odoo>
+    <record id='dashboard_session_graph_display_view' model='ir.actions.act_window'>
+        <field name='name'>Session Graphs</field>
+        <field name='res_model'>session</field>
+        <field name='view_mode'>graph</field>
+        <field name='view_id' ref='session_view_graph'/>
+    </record>
+
+    <record id='dashboard_session_calendar_display_view' model='ir.actions.act_window'>
+        <field name='name'>Session Calendar</field>
+        <field name='res_model'>session</field>
+        <field name='view_mode'>calendar</field>
+        <field name='view_id' ref='session_view_calendar'/>
+    </record>
+
+    <record id='dashboard_view_form' model='ir.ui.view'>
+        <field name='name'>Dashboard</field>
+        <field name='model'>board.board</field>
+        <field name='type'>form</field>
+        <field name='arch' type='xml'>
+            <form string='Dashboard'>
+                <board style='2-1'>
+                    <column>
+                        <action string='Calendar' name='%(dashboard_session_calendar_display_view)d'/>
+                    </column>
+                    <column>
+                        <action string='Courses' name='%(course_action_display_view)d'/>
+                        <action string='Graphs' name='%(dashboard_session_graph_display_view)d'/>
+                    </column>
+                </board>
+            </form>
+        </field>
+    </record>
+
+    <record id='dashboard_display_view' model='ir.actions.act_window'>
+        <field name='name'>Dashboard</field>
+        <field name='res_model'>board.board</field>
+        <field name='view_mode'>form</field>
+        <field name='usage'>menu</field>
+        <field name='view_id' ref='dashboard_view_form'/>
+    </record>
+</odoo>

--- a/open_academy/views/report_session.xml
+++ b/open_academy/views/report_session.xml
@@ -1,0 +1,55 @@
+<odoo>
+    <record id='report_session_view' model='ir.actions.report'>
+        <field name='name'>Open Academy Session Report</field>
+        <field name='model'>session</field>
+        <field name='report_type'>qweb-html</field>
+        <field name='report_name'>open_academy.report_session</field>
+        <field name='report_file'>report_session</field>
+        <field name='binding_model_id' ref='model_session'/>
+        <field name='binding_type'>report</field>
+    </record>
+
+    <template id='open_academy.report_session'>
+        <t t-call='web.html_container'>
+            <t t-foreach='docs' t-as='session'>
+                <t t-call='web.external_layout'>
+                    <div class='page container'>
+                        <div style='margin-bottom: 1em;'>
+                            <h2 style='font-size: 2em;'><span t-field='session.name'/></h2>
+                        </div>
+                        <div style='margin-bottom: 1em'>
+                            <div class='row'>
+                                <div class='col-3'><span>From: </span></div>
+                                <div class='col-3'><span t-field='session.start_date'/></div>
+                                <div class='col-6'></div>
+                            </div>
+                            <div class='row'>
+                                <div class='col-3'><span>To: </span></div>
+                                <div class='col-3'><span t-field='session.stop_date'/></div>
+                                <div class='col-6'></div>
+                            </div>
+                        </div>
+                        <div>
+                            <h3 style='font-size: 1.25em;'>Attendees</h3>
+                            <div class='row' style='border-bottom: solid 1px black; padding: 0.5em 0 0.5em 0;'>
+                                <div class='col-3'><strong>Name</strong></div>
+                                <div class='col-3'><strong>Phone</strong></div>
+                                <div class='col-4'><strong>Email</strong></div>
+                                <div class='col-2'><strong>Country</strong></div>
+                            </div>
+                            <t t-foreach='session.attendee_ids' t-as='attendee'>
+                                <div class='row' style='border-top: solid 1px #c3c8c9; padding: 0.5em 0 0.5em 0; background-color: #fbfdff;'>
+                                    <div class='col-3'><span t-field='attendee.name'/></div>
+                                    <div class='col-3'><span t-field='attendee.phone'/></div>
+                                    <div class='col-4'><span t-field='attendee.email'/></div>
+                                    <div class='col-2'><span t-field='attendee.country_id'/></div>
+                                </div>
+                            </t>
+                            <div class='row' style='border-bottom: solid 1px black;'></div>
+                        </div>
+                    </div>
+                </t>
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/open_academy/views/session.xml
+++ b/open_academy/views/session.xml
@@ -45,7 +45,7 @@
         <field name='name'>session.view.calendar</field>
         <field name='model'>session</field>
         <field name='arch' type='xml'>
-            <calendar string='name' date_start='start_date' date_stop='stop_date' color='course_id'>
+            <calendar string='name' date_start='start_date' date_stop='stop_date' color='course_id' mode='month'>
                 <field name='active'/>
                 <field name='name'/>
                 <field name='course_id'/>

--- a/open_academy/xml_rpc.py
+++ b/open_academy/xml_rpc.py
@@ -1,0 +1,47 @@
+import logging
+import xmlrpc.client
+
+
+def get_sessions(models, database, uid, password):
+    ids = models.execute_kw(database, uid, password, 'session', 'search', [[[1, '=', 1]]])
+    sessions = models.execute_kw(
+        database, uid, password, 'session', 'read',
+        [ids], {'fields': ['name', 'number_of_seats', ]}
+    )
+
+    return sessions
+
+
+def main():
+    logging.basicConfig(filename='session.log', filemode='w', level=logging.INFO)
+    host = 'localhost'
+    port = 8069
+    database = 'odoo_test'
+    user = 'payen'
+    password = 'payen'
+    url = 'http://%s:%d/xmlrpc/' % (host, port)
+
+    uid = xmlrpc.client.ServerProxy(url + 'common').login(database, user, password)
+    models = xmlrpc.client.ServerProxy('{}2/object'.format(url))
+
+    models.execute_kw(
+        database, uid, password, 'session', 'create',
+        [{
+            'name': 'Session xmlrpc',
+            'start_date': '2022-01-24',
+            'stop_date': '2022-01-29',
+            'active': 'TRUE',
+            'duration': 7.5,
+            'number_of_seats': 30,
+            'course_id': 1,
+        }])
+
+    sessions = get_sessions(models, database, uid, password)
+
+    for session in sessions:
+        msg = '{} ------ seats: {}'.format(session["name"], session['number_of_seats'])
+        logging.info(msg)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Selecting a session or multiple sessions will now spawn the "print" button. 
![image](https://user-images.githubusercontent.com/49595803/151005944-34a7c206-85df-4921-b314-c8b297259aae.png)

Clicking on it will generate a report for every selected session; these reports include the sessions' names, their starting and ending dates, and their attendees:
![Screenshot from 2022-01-25 08-31-17](https://user-images.githubusercontent.com/49595803/151007371-99a8eaf1-ae51-42e0-9512-29cd0892f86d.png)

A dashboard that displays sessions' dates, number of sessions per course, and every course in list form was also added:
![image](https://user-images.githubusercontent.com/49595803/151007792-2a15d6c2-6f1f-47ce-9dd3-5b08de2f03f0.png)

Finally, a script that retrieves every session with their numbers of seats, and creates a new session, was implemented:
![image](https://user-images.githubusercontent.com/49595803/151008078-0fff9934-279f-4c4a-a2d7-fa09d31d5ec1.png)
![image](https://user-images.githubusercontent.com/49595803/151011951-217fd745-2b1e-406f-a6ce-82d2d1a56110.png)


 
